### PR TITLE
Expose Prometheus metrics via HTTP

### DIFF
--- a/ESP32Agri.ino
+++ b/ESP32Agri.ino
@@ -52,6 +52,16 @@ void setup() {
     request->send(200, "text/html", html);
   });
 
+  server.on("/metrics", HTTP_GET, [](AsyncWebServerRequest *request){
+    String metrics = "# HELP moisture_raw Soil moisture value (0-4095)\n";
+    metrics += "# TYPE moisture_raw gauge\n";
+    metrics += "moisture_raw " + String(analogValue) + "\n";
+    metrics += "# HELP uptime_seconds ESP32 uptime in seconds\n";
+    metrics += "# TYPE uptime_seconds counter\n";
+    metrics += "uptime_seconds " + String(millis() / 1000) + "\n";
+    request->send(200, "text/plain", metrics);
+  });
+
   server.onNotFound([](AsyncWebServerRequest *request){
     request->send(404, "text/plain", "404: Not found");
   });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  prometheus:
+    image: prom/prometheus
+    container_name: agri-prom
+    ports:
+      - "127.0.0.1:9090:9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,11 @@
+global:
+  external_labels:
+    monitor: 'agri-monitor'  # label for external services
+
+scrape_configs:
+  - job_name: 'esp32'
+    scrape_interval: 10s
+    static_configs:
+      - targets: ['<ip_address>:80']
+        labels:
+          group: 'dev'


### PR DESCRIPTION
## What does this PR do?
- Add a Prometheus endpoint to the http server
- Add resources to spin up a Prometheus container

## Motivation
To get soil moisture metrics.
This PR addresses the issue #1